### PR TITLE
Displays the attribute value in its label when Load Roleplayers is enabled

### DIFF
--- a/src/renderer/components/shared/CanvasDataBuilder.js
+++ b/src/renderer/components/shared/CanvasDataBuilder.js
@@ -165,7 +165,7 @@ const getInstanceNode = async (instance, graqlVar, explanation) => {
       break;
     }
     case ATTRIBUTE_INSTANCE: {
-      node.value = await instance.value();
+      node.value = await convertToRemote(instance).value();
       node.label = await getNodeLabelWithAttrs(`${node.type}: ${node.value}`, node.type, instance);
       break;
     }


### PR DESCRIPTION
## What is the goal of this PR?
When querying for a relation without specifying its roleplayers, the auto-loaded attribute roleplayer now contains the attribute's value as a part of its label.

## What are the changes implemented in this PR?
- expect a remote instance passed on to `getInstanceNode` in `CDB`
- modified `buildRPInstances > getRolePlayersData` to not resolve too early 
