### PR TITLE
Deep sign TypeDB Driver and notarise Mac snapshots

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,13 @@ commands:
           # 2) jpackage does not support 0 as a major version
           # This writes VERSION-SHA1 into the VERSION file to be used by the assembly rule.
           echo $(cat VERSION)-$CIRCLE_SHA1 > VERSION
-          bazel run //:deploy-mac-<<parameters.target-arch>>-dmg --compilation_mode=opt --spawn_strategy=local -- snapshot
+          bazel run //:deploy-mac-<<parameters.target-arch>>-dmg --compilation_mode=opt \
+              --define APPLE_CODE_SIGN=yes \
+              --define APPLE_ID=$APPLE_ID \
+              --define APPLE_ID_PASSWORD=$APPLE_ID_PASSWORD \
+              --define APPLE_TEAM_ID=$APPLE_TEAM_ID \
+              --define APPLE_CODE_SIGNING_CERT_PASSWORD=$APPLE_CODE_SIGNING_CERT_PASSWORD \
+              --spawn_strategy=local -- snapshot
 
   deploy-mac-release:
     parameters:

--- a/BUILD
+++ b/BUILD
@@ -176,7 +176,7 @@ assemble_jvm_platform(
     mac_app_id = "com.typedb.studio",
     mac_entitlements = "//config/mac:entitlements-mac-plist",
     mac_code_signing_cert = "@vaticle_apple_developer_id_application_cert//file",
-    mac_deep_sign_jars_regex = ".*io-netty-netty.*",
+    mac_deep_sign_jars_regex = ".*(io-netty-netty|typedb-typedb-driver).*",
     windows_menu_group = "TypeDB Studio",
 )
 


### PR DESCRIPTION
## Usage and product changes

- TypeDB Driver `.dylib` and `.jnilib` files will now be deep signed to ensure correct notarisation
- We now perform code signing for Mac snapshots, to catch issues with it prior to release

## Implementation

- Expand the `mac_deep_sign_jars_regex`
- Add the required parameters when deploying mac snapshots