### PR TITLE
Update CircleCI image for Release Cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,7 +316,7 @@ jobs:
 
   release-cleanup:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:2023.10.1
     steps:
       - checkout
       - run: git push --delete https://$REPO_GITHUB_TOKEN@github.com/vaticle/typedb-studio.git $CIRCLE_BRANCH


### PR DESCRIPTION
## Usage and product changes

Update the CircleCI image used for the Release Cleanup job

## Motivation

The existing image was invalid, and thus the job failed

## Implementation

We update the image to the same one we use for linux release
