### PR TITLE
Allow URI schemes in addresses

### DIFF
--- a/module/connection/ServerDialog.kt
+++ b/module/connection/ServerDialog.kt
@@ -72,6 +72,8 @@ import com.typedb.studio.service.connection.DriverState.Status.CONNECTED
 import com.typedb.studio.service.connection.DriverState.Status.CONNECTING
 import com.typedb.studio.service.connection.DriverState.Status.DISCONNECTED
 import com.vaticle.typedb.driver.api.TypeDBCredential
+import java.net.URI
+import java.net.URISyntaxException
 import java.nio.file.Path
 import androidx.compose.ui.window.DialogState as ComposeDialogState
 
@@ -223,7 +225,10 @@ object ServerDialog {
 
     private fun addressFormatIsValid(address: String): Boolean {
         if (address.isBlank()) return true
-        val tokens = address.split(":")
+        val cleanedAddress = if (address.contains("://")) {
+            address.split("://", limit = 2).getOrElse(1) { "" }
+        } else address
+        val tokens = cleanedAddress.split(":")
         val hostIsValid = tokens.isNotEmpty() && !tokens[0].contains(Regex("\\s"))
         val portIsValid = tokens.size > 1 && tokens[1].toIntOrNull()?.let { it in 0..65535 } == true
         return tokens.size == 2 && hostIsValid && portIsValid

--- a/module/connection/ServerDialog.kt
+++ b/module/connection/ServerDialog.kt
@@ -225,10 +225,7 @@ object ServerDialog {
 
     private fun addressFormatIsValid(address: String): Boolean {
         if (address.isBlank()) return true
-        val cleanedAddress = if (address.contains("://")) {
-            address.split("://", limit = 2).getOrElse(1) { "" }
-        } else address
-        val tokens = cleanedAddress.split(":")
+        val tokens = address.split(Regex(":(?!//)"))
         val hostIsValid = tokens.isNotEmpty() && !tokens[0].contains(Regex("\\s"))
         val portIsValid = tokens.size > 1 && tokens[1].toIntOrNull()?.let { it in 0..65535 } == true
         return tokens.size == 2 && hostIsValid && portIsValid

--- a/module/connection/ServerDialog.kt
+++ b/module/connection/ServerDialog.kt
@@ -72,8 +72,6 @@ import com.typedb.studio.service.connection.DriverState.Status.CONNECTED
 import com.typedb.studio.service.connection.DriverState.Status.CONNECTING
 import com.typedb.studio.service.connection.DriverState.Status.DISCONNECTED
 import com.vaticle.typedb.driver.api.TypeDBCredential
-import java.net.URI
-import java.net.URISyntaxException
 import java.nio.file.Path
 import androidx.compose.ui.window.DialogState as ComposeDialogState
 

--- a/service/common/util/ConnectionUri.kt
+++ b/service/common/util/ConnectionUri.kt
@@ -62,7 +62,7 @@ object ConnectionUri {
         val (username, password) = auth.split(":", limit = 2).let { Pair(it[0], it.getOrNull(1)) }
         val decodedPassword = password?.let { URLDecoder.decode(it, Charset.defaultCharset()) }
 
-        val (addressesString, path) = connection?.split("(?<![:/])/".toRegex(), limit = 2)?.let { Pair(it[0], it.getOrNull(1)) } ?: Pair(null, null)
+        val (addressesString, path) = connection?.split(Regex("(?<![:/])/"), limit = 2)?.let { Pair(it[0], it.getOrNull(1)) } ?: Pair(null, null)
         val addresses = addressesString?.split(",").orEmpty()
         val queryParams = path?.split("?")?.lastOrNull()?.split("&")?.associate {
             it.split("=", limit = 2).let { Pair(it[0], it.getOrNull(1)) }

--- a/service/common/util/ConnectionUri.kt
+++ b/service/common/util/ConnectionUri.kt
@@ -6,23 +6,21 @@
 
 package com.typedb.studio.service.common.util
 
-import java.net.URI
-import java.net.URISyntaxException
 import java.net.URLDecoder
 import java.nio.charset.Charset
 
 object ConnectionUri {
-    private const val SCHEME_CLOUD = "typedb-cloud"
-    private const val SCHEME_CORE = "typedb-core"
+    private const val SCHEME_CLOUD = "typedb-cloud://"
+    private const val SCHEME_CORE = "typedb-core://"
     private const val ADDRESSES_SEPARATOR = ","
     private const val ADDRESS_TRANSLATION_SEPARATOR = ";"
     private const val TLS_ENABLED = "tlsEnabled"
     val PLACEHOLDER_URI = buildCloud(Label.USERNAME.lowercase(), Label.PASSWORD.lowercase(), listOf(Label.ADDRESS.lowercase()), true)
 
-    fun buildCore(address: String) = "$SCHEME_CORE://$address"
+    fun buildCore(address: String) = "$SCHEME_CORE$address"
 
     fun buildCloud(username: String, password: String, addresses: List<String>, tlsEnabled: Boolean)=
-        "$SCHEME_CLOUD://$username:$password@${addresses.joinToString(ADDRESSES_SEPARATOR)}/?$TLS_ENABLED=${tlsEnabled}"
+        "$SCHEME_CLOUD$username:$password@${addresses.joinToString(ADDRESSES_SEPARATOR)}/?$TLS_ENABLED=${tlsEnabled}"
 
     fun buildCloudTranslated(username: String, password: String, translatedAddresses: List<Pair<String, String>>, tlsEnabled: Boolean) = buildCloud (
         username, password, translatedAddresses.map { (a, b) -> "$a$ADDRESS_TRANSLATION_SEPARATOR$b" }, tlsEnabled
@@ -47,46 +45,50 @@ object ConnectionUri {
     ): ParsedCloudConnectionUri
 
     fun parse(connectionUri: String): ParsedConnectionUri? {
-        val uri = try { URI(connectionUri) } catch (_: URISyntaxException) { return null }
-
-        if (uri.scheme == SCHEME_CLOUD) {
-            val (username, password, addresses) = uri.authority?.let {
-                val (auth, address) = it.split("@", limit = 2)
-                    .let { Pair(it[0], it.getOrNull(1)) }
-                val (username, password) = auth.split(":", limit = 2)
-                    .let { Pair(it[0], it.getOrNull(1)) }
-                val addresses = address?.split(ADDRESSES_SEPARATOR) ?: emptyList()
-                Triple(username, password, addresses)
-            } ?: Triple(null, null, emptyList())
-
-            val queryParams = uri.query?.split("&")?.associate {
-                it.split("=", limit = 2).let { Pair(it[0], it.getOrNull(1)) }
-            }
-
-            val decodedPassword = password?.let { URLDecoder.decode(it, Charset.defaultCharset()) }
-            val tlsEnabled = queryParams?.get(TLS_ENABLED)?.toBoolean()
-            if (addresses.getOrNull(0)?.contains(ADDRESS_TRANSLATION_SEPARATOR) == true) {
-                return ParsedCloudTranslatedConnectionUri(
-                    username = username,
-                    password = decodedPassword,
-                    addresses = addresses.map {
-                        it.split(ADDRESS_TRANSLATION_SEPARATOR, limit = 2).let { Pair(it[0], it.getOrNull(1)) }
-                    }.filter { it.second != null }.map { it.first to it.second!! },
-                    tlsEnabled = tlsEnabled
-                )
-            } else {
-                return ParsedCloudUntranslatedConnectionUri(
-                    username = username,
-                    password = decodedPassword,
-                    addresses = addresses,
-                    tlsEnabled = tlsEnabled
-                )
-            }
-        } else if (uri.scheme == SCHEME_CORE && !uri.authority.isNullOrBlank()) {
-            return ParsedCoreConnectionUri(uri.authority)
+        return if (connectionUri.startsWith(SCHEME_CLOUD)) {
+            val k = parseCloud(connectionUri.removePrefix(SCHEME_CLOUD))
+            println(k)
+            k
+        } else if (connectionUri.startsWith(SCHEME_CORE)) {
+            parseCore(connectionUri.removePrefix(SCHEME_CORE))
         } else {
-            return null
+            null
         }
     }
 
+    private fun parseCloud(connectionUri: String): ParsedCloudConnectionUri {
+        val (auth, connection) = connectionUri.split("@", limit = 2).let { Pair(it[0], it.getOrNull(1)) }
+
+        val (username, password) = auth.split(":", limit = 2).let { Pair(it[0], it.getOrNull(1)) }
+        val decodedPassword = password?.let { URLDecoder.decode(it, Charset.defaultCharset()) }
+
+        val (addressesString, path) = connection?.split("(?<![:/])/".toRegex(), limit = 2)?.let { Pair(it[0], it.getOrNull(1)) } ?: Pair(null, null)
+        val addresses = addressesString?.split(",").orEmpty()
+        val queryParams = path?.split("?")?.lastOrNull()?.split("&")?.associate {
+            it.split("=", limit = 2).let { Pair(it[0], it.getOrNull(1)) }
+        }
+        val tlsEnabled = queryParams?.get(TLS_ENABLED)?.toBoolean()
+
+        return if (addresses.getOrNull(0)?.contains(ADDRESS_TRANSLATION_SEPARATOR) == true) {
+            ParsedCloudTranslatedConnectionUri(
+                username = username,
+                password = decodedPassword,
+                addresses = addresses.map {
+                    it.split(ADDRESS_TRANSLATION_SEPARATOR, limit = 2).let { Pair(it[0], it.getOrNull(1)) }
+                }.filter { it.second != null }.map { it.first to it.second!! },
+                tlsEnabled = tlsEnabled
+            )
+        } else {
+            ParsedCloudUntranslatedConnectionUri(
+                username = username,
+                password = decodedPassword,
+                addresses = addresses,
+                tlsEnabled = tlsEnabled
+            )
+        }
+    }
+
+    private fun parseCore(connectionUri: String): ParsedCoreConnectionUri? {
+        return if (connectionUri.isBlank()) null else ParsedCoreConnectionUri(connectionUri)
+    }
 }

--- a/service/common/util/ConnectionUri.kt
+++ b/service/common/util/ConnectionUri.kt
@@ -46,9 +46,7 @@ object ConnectionUri {
 
     fun parse(connectionUri: String): ParsedConnectionUri? {
         return if (connectionUri.startsWith(SCHEME_CLOUD)) {
-            val k = parseCloud(connectionUri.removePrefix(SCHEME_CLOUD))
-            println(k)
-            k
+            parseCloud(connectionUri.removePrefix(SCHEME_CLOUD))
         } else if (connectionUri.startsWith(SCHEME_CORE)) {
             parseCore(connectionUri.removePrefix(SCHEME_CORE))
         } else {


### PR DESCRIPTION
## Usage and product changes

We allow the use of URI schemes (for example, `https://` or `http://`) in connection addresses

## Motivation

Currently, our driver assumes `http://` if no scheme is supplied - sometimes, another scheme (such as `https://`) may be required. This is not possible through studio.

## Implementation

Two points are required to make this functional:
- Correct the `addressFormatIsValid` check to not view the `:` in a scheme as being a port delimiter. We achieve this through a regex with a negative lookahead, so that rather than splitting on `:` it splits on `:` not followed by `//`
- Rewrite the ConnectionURI parser to support schemes in addresses. We can no longer use the built-in `URI` class to parse it, as that fails when the addresses have a scheme. Similarly to address format checks, we make use of a regex with a negative lookbehind so that when we split on `/` to get the path, we only split on `/` not preceded by `/` or `:`
