### PR TITLE
Fix printing of variables with empty values and rows with no columns

### DIFF
--- a/framework/output/LogOutput.kt
+++ b/framework/output/LogOutput.kt
@@ -14,6 +14,8 @@ import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.unit.dp
+import com.typedb.driver.api.QueryType
+import com.typedb.driver.api.Transaction
 import com.typedb.driver.api.answer.ConceptRow
 import com.typedb.driver.api.answer.JSON
 import com.typedb.driver.api.concept.Concept
@@ -23,7 +25,6 @@ import com.typedb.driver.api.concept.instance.Instance
 import com.typedb.driver.api.concept.instance.Relation
 import com.typedb.driver.api.concept.type.Type
 import com.typedb.driver.api.concept.value.Value
-import com.typedb.driver.common.exception.TypeDBDriverException
 import com.typedb.studio.framework.common.Util
 import com.typedb.studio.framework.common.theme.Color
 import com.typedb.studio.framework.common.theme.Theme
@@ -37,18 +38,24 @@ import com.typedb.studio.service.common.util.Label
 import com.typedb.studio.service.common.util.Message
 import com.typedb.studio.service.common.util.Property
 import com.typedb.studio.service.connection.QueryRunner.Response
-import com.typedb.studio.service.connection.QueryRunner.Response.Message.Type.*
+import com.typedb.studio.service.connection.QueryRunner.Response.Message.Type.ERROR
+import com.typedb.studio.service.connection.QueryRunner.Response.Message.Type.INFO
+import com.typedb.studio.service.connection.QueryRunner.Response.Message.Type.SUCCESS
+import com.typedb.studio.service.connection.QueryRunner.Response.Message.Type.TYPEQL
 import com.typedb.studio.service.connection.TransactionState
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import mu.KotlinLogging
-import java.util.*
+import com.typeql.lang.common.TypeQLToken
+import com.typeql.lang.common.util.Strings
+import java.io.PrintStream
+import java.util.Arrays
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import java.util.stream.Collectors
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import mu.KotlinLogging
 
 internal class LogOutput constructor(
     private val editorState: TextEditor.State,

--- a/framework/output/LogOutput.kt
+++ b/framework/output/LogOutput.kt
@@ -14,8 +14,6 @@ import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.unit.dp
-import com.typedb.driver.api.QueryType
-import com.typedb.driver.api.Transaction
 import com.typedb.driver.api.answer.ConceptRow
 import com.typedb.driver.api.answer.JSON
 import com.typedb.driver.api.concept.Concept
@@ -25,6 +23,7 @@ import com.typedb.driver.api.concept.instance.Instance
 import com.typedb.driver.api.concept.instance.Relation
 import com.typedb.driver.api.concept.type.Type
 import com.typedb.driver.api.concept.value.Value
+import com.typedb.driver.common.exception.TypeDBDriverException
 import com.typedb.studio.framework.common.Util
 import com.typedb.studio.framework.common.theme.Color
 import com.typedb.studio.framework.common.theme.Theme
@@ -38,24 +37,18 @@ import com.typedb.studio.service.common.util.Label
 import com.typedb.studio.service.common.util.Message
 import com.typedb.studio.service.common.util.Property
 import com.typedb.studio.service.connection.QueryRunner.Response
-import com.typedb.studio.service.connection.QueryRunner.Response.Message.Type.ERROR
-import com.typedb.studio.service.connection.QueryRunner.Response.Message.Type.INFO
-import com.typedb.studio.service.connection.QueryRunner.Response.Message.Type.SUCCESS
-import com.typedb.studio.service.connection.QueryRunner.Response.Message.Type.TYPEQL
+import com.typedb.studio.service.connection.QueryRunner.Response.Message.Type.*
 import com.typedb.studio.service.connection.TransactionState
-import com.typeql.lang.common.TypeQLToken
-import com.typeql.lang.common.util.Strings
-import java.io.PrintStream
-import java.util.Arrays
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import mu.KotlinLogging
+import java.util.*
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import java.util.stream.Collectors
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import mu.KotlinLogging
 
 internal class LogOutput constructor(
     private val editorState: TextEditor.State,
@@ -249,16 +242,23 @@ internal class LogOutput constructor(
         val content = columnNames
             .stream()
             .map { columnName: String ->
-                val concept = conceptRow[columnName]
                 val sb = StringBuilder("$")
                 sb.append(columnName)
                 sb.append(" ".repeat(columnsWidth - columnName.length + 1))
                 sb.append("| ")
-                sb.append(conceptDisplayString(if (concept.isValue) concept.asValue() else concept))
+                try {
+                    val concept = conceptRow[columnName]
+                    sb.append(conceptDisplayString(if (concept.isValue) concept.asValue() else concept))
+                } catch (_: TypeDBDriverException) {
+                    // TODO: substitute the "try catch" by an optional processing when implemented
+                }
                 sb.toString()
             }.collect(Collectors.joining("\n"))
 
         val sb = StringBuilder(indent(CONTENT_INDENT, content))
+        if (content.isEmpty()) {
+            sb.append("Row does not have columns to show")
+        }
         sb.append("\n")
         sb.append(lineDashSeparator(columnsWidth))
         return sb.toString()


### PR DESCRIPTION
## Usage and product changes
Enhance printing logic to handle two special cases of received answers:
* When a variable with no values is returned, an empty result will be shown instead of a crash (it used to be considered an impossible situation).
* When concept rows are returned, but they do not have any columns inside (possible for delete stages), a special message is written for every row processed (this behavior is temporarily different from Console).

## Motivation
We replicate the bugfixes from TypeDB Console https://github.com/typedb/typedb-console/pull/271.

## Implementation
Fix for the first issue:
```
## Result> Success.
    $empty | 
    $u     | iid 0x1e00000000000000000020 isa user
   ------------
## Completed
```

Fix for the second issue:
```
## Result> Success.
Row does not have columns to show
   -------
Row does not have columns to show
   -------
Row does not have columns to show
   -------
Row does not have columns to show
   -------
Row does not have columns to show
   -------
Row does not have columns to show
   -------
Row does not have columns to show
   -------
Row does not have columns to show
   -------
Row does not have columns to show
   -------
## Completed
```

The implementation is similar to TypeDB Console https://github.com/typedb/typedb-console/pull/271. However, due to differences in architecture and the current state of the printing logic of Studio, the fix for the second issue is different, and the "no columns" message is printed for every row processed instead of a single message.
The reasons are:
* Refactoring of Studio printing will take much more time and will also pull other things in the context.
* Studio does not currently print the total number of answers processed (see the related Console PR for comparison). This way, printing this message multiple times is actually useful.