### PR TITLE
Update the Driver dependency to work with optional concepts from rows

### DIFF
--- a/RELEASE_NOTES_LATEST.md
+++ b/RELEASE_NOTES_LATEST.md
@@ -22,8 +22,8 @@ which versions of Studio are compatible with which versions of TypeDB server.
 ## Bugs Fixed
 - **Fix printing of variables with empty values and rows with no columns**
   Enhance printing logic to handle two special cases of received answers:
-    * When a variable with no values is returned, an empty result will be shown instead of a crash (it used to be considered an impossible situation).
-    * When concept rows are returned, but they do not have any columns inside (possible for delete stages), a special message is written for every row processed (this behavior is temporarily different from Console).
+  * When a variable with no values is returned, an empty result will be shown instead of a crash (it used to be considered an impossible situation).
+  * When concept rows are returned, but they do not have any columns inside (possible for delete stages), a special message is written for every row processed (this behavior is temporarily different from Console).
 
 
 

--- a/RELEASE_NOTES_LATEST.md
+++ b/RELEASE_NOTES_LATEST.md
@@ -22,10 +22,10 @@ which versions of Studio are compatible with which versions of TypeDB server.
 ## Bugs Fixed
 - **Fix printing of variables with empty values and rows with no columns**
   Enhance printing logic to handle two special cases of received answers:
-  * When a variable with no values is returned, an empty result will be shown instead of a crash (it used to be considered an impossible situation).
-  * When concept rows are returned, but they do not have any columns inside (possible for delete stages), a special message is written for every row processed (this behavior is temporarily different from Console).
-  
-  
+    * When a variable with no values is returned, an empty result will be shown instead of a crash (it used to be considered an impossible situation).
+    * When concept rows are returned, but they do not have any columns inside (possible for delete stages), a special message is written for every row processed (this behavior is temporarily different from Console).
+
+
 
 ## Code Refactors
 
@@ -33,4 +33,3 @@ which versions of Studio are compatible with which versions of TypeDB server.
 ## Other Improvements
 
     
-

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -26,9 +26,8 @@ def typeql():
     )
 
 def typedb_driver():
-    # TODO: Return typedb after merges
     git_repository(
         name = "typedb_driver",
-        remote = "https://github.com/farost/typedb-driver",
-        commit = "f1f0ac3725436cd180534f95b000ad8c04e79dc9",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
+        remote = "https://github.com/typedb/typedb-driver",
+        commit = "c0653ca0615f4075492f0b098960d291468ebd91",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -26,8 +26,9 @@ def typeql():
     )
 
 def typedb_driver():
+    # TODO: Return typedb after merges
     git_repository(
         name = "typedb_driver",
-        remote = "https://github.com/typedb/typedb-driver",
-        commit = "42f4ba3cb8a857c5810ddb9644d63e7fb2c832c4",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
+        remote = "https://github.com/farost/typedb-driver",
+        commit = "f1f0ac3725436cd180534f95b000ad8c04e79dc9",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
     )

--- a/framework/output/LogOutput.kt
+++ b/framework/output/LogOutput.kt
@@ -14,8 +14,6 @@ import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.unit.dp
-import com.typedb.driver.api.QueryType
-import com.typedb.driver.api.Transaction
 import com.typedb.driver.api.answer.ConceptRow
 import com.typedb.driver.api.answer.JSON
 import com.typedb.driver.api.concept.Concept
@@ -25,7 +23,6 @@ import com.typedb.driver.api.concept.instance.Instance
 import com.typedb.driver.api.concept.instance.Relation
 import com.typedb.driver.api.concept.type.Type
 import com.typedb.driver.api.concept.value.Value
-import com.typedb.driver.common.exception.TypeDBDriverException
 import com.typedb.studio.framework.common.Util
 import com.typedb.studio.framework.common.theme.Color
 import com.typedb.studio.framework.common.theme.Theme
@@ -39,24 +36,18 @@ import com.typedb.studio.service.common.util.Label
 import com.typedb.studio.service.common.util.Message
 import com.typedb.studio.service.common.util.Property
 import com.typedb.studio.service.connection.QueryRunner.Response
-import com.typedb.studio.service.connection.QueryRunner.Response.Message.Type.ERROR
-import com.typedb.studio.service.connection.QueryRunner.Response.Message.Type.INFO
-import com.typedb.studio.service.connection.QueryRunner.Response.Message.Type.SUCCESS
-import com.typedb.studio.service.connection.QueryRunner.Response.Message.Type.TYPEQL
+import com.typedb.studio.service.connection.QueryRunner.Response.Message.Type.*
 import com.typedb.studio.service.connection.TransactionState
-import com.typeql.lang.common.TypeQLToken
-import com.typeql.lang.common.util.Strings
-import java.io.PrintStream
-import java.util.Arrays
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import mu.KotlinLogging
+import java.util.*
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import java.util.stream.Collectors
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import mu.KotlinLogging
 
 internal class LogOutput constructor(
     private val editorState: TextEditor.State,
@@ -254,11 +245,10 @@ internal class LogOutput constructor(
                 sb.append(columnName)
                 sb.append(" ".repeat(columnsWidth - columnName.length + 1))
                 sb.append("| ")
-                try {
-                    val concept = conceptRow[columnName]
+                val conceptOptional = conceptRow[columnName]
+                if (conceptOptional.isPresent) {
+                    val concept = conceptOptional.get()
                     sb.append(conceptDisplayString(if (concept.isValue) concept.asValue() else concept))
-                } catch (_: TypeDBDriverException) {
-                    // TODO: substitute the "try catch" by an optional processing when implemented
                 }
                 sb.toString()
             }.collect(Collectors.joining("\n"))

--- a/framework/output/LogOutput.kt
+++ b/framework/output/LogOutput.kt
@@ -14,6 +14,8 @@ import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.unit.dp
+import com.typedb.driver.api.QueryType
+import com.typedb.driver.api.Transaction
 import com.typedb.driver.api.answer.ConceptRow
 import com.typedb.driver.api.answer.JSON
 import com.typedb.driver.api.concept.Concept
@@ -36,18 +38,24 @@ import com.typedb.studio.service.common.util.Label
 import com.typedb.studio.service.common.util.Message
 import com.typedb.studio.service.common.util.Property
 import com.typedb.studio.service.connection.QueryRunner.Response
-import com.typedb.studio.service.connection.QueryRunner.Response.Message.Type.*
+import com.typedb.studio.service.connection.QueryRunner.Response.Message.Type.ERROR
+import com.typedb.studio.service.connection.QueryRunner.Response.Message.Type.INFO
+import com.typedb.studio.service.connection.QueryRunner.Response.Message.Type.SUCCESS
+import com.typedb.studio.service.connection.QueryRunner.Response.Message.Type.TYPEQL
 import com.typedb.studio.service.connection.TransactionState
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import mu.KotlinLogging
-import java.util.*
+import com.typeql.lang.common.TypeQLToken
+import com.typeql.lang.common.util.Strings
+import java.io.PrintStream
+import java.util.Arrays
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import java.util.stream.Collectors
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import mu.KotlinLogging
 
 internal class LogOutput constructor(
     private val editorState: TextEditor.State,


### PR DESCRIPTION
## Usage and product changes
Update the Driver dependency to work with optional concepts from rows

## Motivation
Replace a temporary `try {} catch` solution with an updated API's call. 

## Implementation
Check the optional result and get its concept instead of a temporary `try {} catch` block.