### PR TITLE
Update TypeDB driver dependency and constructor

### DIFF
--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -29,5 +29,5 @@ def typedb_driver():
     git_repository(
         name = "typedb_driver",
         remote = "https://github.com/typedb/typedb-driver",
-        tag = "3.0.5",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
+        commit = "1cdc53008dd5ce578cb0224beb358cbe1bdbacd4",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_driver
     )

--- a/module/connection/ServerDialog.kt
+++ b/module/connection/ServerDialog.kt
@@ -6,11 +6,24 @@
 
 package com.typedb.studio.module.connection
 
+import androidx.compose.ui.window.DialogState as ComposeDialogState
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Divider
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.ComposeDialog
@@ -24,7 +37,9 @@ import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.WindowPosition.Aligned
 import com.typedb.studio.framework.common.theme.Theme
 import com.typedb.studio.framework.common.theme.Theme.TOOLBAR_BUTTON_SIZE
-import com.typedb.studio.framework.material.*
+import com.typedb.studio.framework.material.ActionableList
+import com.typedb.studio.framework.material.Dialog
+import com.typedb.studio.framework.material.Form
 import com.typedb.studio.framework.material.Form.Checkbox
 import com.typedb.studio.framework.material.Form.FIELD_HEIGHT
 import com.typedb.studio.framework.material.Form.Field
@@ -39,7 +54,10 @@ import com.typedb.studio.framework.material.Form.TextButtonRow
 import com.typedb.studio.framework.material.Form.TextInput
 import com.typedb.studio.framework.material.Form.TextInputValidated
 import com.typedb.studio.framework.material.Form.toggleButtonColor
+import com.typedb.studio.framework.material.Icon
+import com.typedb.studio.framework.material.SelectFileDialog
 import com.typedb.studio.framework.material.SelectFileDialog.SelectorOptions
+import com.typedb.studio.framework.material.Tooltip
 import com.typedb.studio.service.Service
 import com.typedb.studio.service.common.util.ConnectionUri
 import com.typedb.studio.service.common.util.ConnectionUri.ParsedCloudConnectionUri
@@ -54,7 +72,6 @@ import com.typedb.studio.service.common.util.Sentence
 import com.typedb.studio.service.connection.DriverState.Status.CONNECTED
 import com.typedb.studio.service.connection.DriverState.Status.CONNECTING
 import com.typedb.studio.service.connection.DriverState.Status.DISCONNECTED
-import androidx.compose.ui.window.DialogState as ComposeDialogState
 
 object ServerDialog {
 

--- a/module/connection/ServerDialog.kt
+++ b/module/connection/ServerDialog.kt
@@ -153,9 +153,10 @@ object ServerDialog {
             }
             val address = when (server) {
                 TYPEDB_CORE -> coreAddress
-                TYPEDB_CLOUD -> {
-                    assert(!useCloudTranslatedAddress) { "Address translation is not supported in 3.x" }
-                    cloudAddresses.first()
+                // Cloud features are not available, just get the first available address and return an error in worst case scenario
+                TYPEDB_CLOUD -> when {
+                    useCloudTranslatedAddress -> cloudTranslatedAddresses.first().first
+                    else -> cloudAddresses.first()
                 }
             }
             Service.driver.tryConnectToTypeDBAsync(

--- a/service/connection/DriverState.kt
+++ b/service/connection/DriverState.kt
@@ -16,7 +16,6 @@ import com.typedb.driver.api.DriverOptions
 import com.typedb.driver.api.Transaction
 import com.typedb.driver.api.user.UserManager
 import com.typedb.driver.common.exception.TypeDBDriverException
-import com.typedb.studio.service.Service
 import com.typedb.studio.service.common.DataService
 import com.typedb.studio.service.common.NotificationService
 import com.typedb.studio.service.common.NotificationService.Companion.launchAndHandle
@@ -130,12 +129,13 @@ class DriverState(
 
         val address = when (dataSrv.connection.server!!) {
             TYPEDB_CORE -> dataSrv.connection.coreAddress!!
-            TYPEDB_CLOUD -> {
-                assert(!dataSrv.connection.useCloudAddressTranslation!!) { "Address translation is not supported in 3.x" }
-                dataSrv.connection.cloudAddresses!!.first()
+            // Cloud features are not available, just get the first available address and return an error in worst case scenario
+            TYPEDB_CLOUD -> when {
+                dataSrv.connection.useCloudAddressTranslation!! -> dataSrv.connection.cloudAddressTranslation!!.first().first
+                else -> dataSrv.connection.cloudAddresses!!.first()
             }
         }
-        Service.driver.tryConnectToTypeDBAsync(
+        tryConnectToTypeDBAsync(
             address, username, newPassword, tlsEnabled, caCertificate, onSuccess
         )
     }

--- a/service/connection/DriverState.kt
+++ b/service/connection/DriverState.kt
@@ -32,7 +32,9 @@ import com.typedb.studio.service.common.util.Message.Connection.Companion.UNABLE
 import com.typedb.studio.service.common.util.Message.Connection.Companion.UNEXPECTED_ERROR
 import com.typedb.studio.service.common.util.Property.Server.TYPEDB_CLOUD
 import com.typedb.studio.service.common.util.Property.Server.TYPEDB_CORE
-import com.typedb.studio.service.connection.DriverState.Status.*
+import com.typedb.studio.service.connection.DriverState.Status.CONNECTED
+import com.typedb.studio.service.connection.DriverState.Status.CONNECTING
+import com.typedb.studio.service.connection.DriverState.Status.DISCONNECTED
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import mu.KotlinLogging


### PR DESCRIPTION
## Usage and product changes
Update TypeDB driver dependency and use the unified driver constructor to support the latest API.

## Implementation
When Cloud mode is used, we just pick the first selected address and send the request (for address translation, it will probably fail the request with a connection error). It's the easiest thing we can do considering that the UI is not locked in 3.x even if the feature is not available.