### PR TITLE
Add value type constraint to structure

### DIFF
--- a/src/framework/graph-visualiser/graph.ts
+++ b/src/framework/graph-visualiser/graph.ts
@@ -22,7 +22,7 @@ import {
     QueryConstraintPlays,
     QueryConstraintRelates,
     QueryConstraintSpan,
-    QueryConstraintSub, QueryConstraintSubExact, QueryStructure,
+    QueryConstraintSub, QueryConstraintSubExact, QueryConstraintValue, QueryStructure,
     QueryVertex,
 } from "../typedb-driver/query-structure";
 import {ConceptRow, ConceptRowsQueryResponse} from "../typedb-driver/response";
@@ -51,7 +51,7 @@ export type DataGraph = {
 export type DataConstraintAny = DataConstraintIsa | DataConstraintIsaExact | DataConstraintHas | DataConstraintLinks |
     DataConstraintSub | DataConstraintSubExact | DataConstraintOwns | DataConstraintRelates | DataConstraintPlays |
     DataConstraintExpression | DataConstraintFunction | DataConstraintComparison |
-    DataConstraintIs | DataConstraintIid | DataConstraintLabel | DataConstraintKind;
+    DataConstraintIs | DataConstraintIid | DataConstraintLabel | DataConstraintValue | DataConstraintKind;
 
 export type DataConstraintSpan = QueryConstraintSpan;
 
@@ -211,6 +211,16 @@ export interface DataConstraintLabel {
 
     type: Type | VertexUnavailable,
     label: string,
+}
+
+export interface DataConstraintValue {
+    tag: "value",
+    textSpan: DataConstraintSpan,
+    queryCoordinates: QueryCoordinates,
+    queryConstraint: QueryConstraintValue,
+
+    attributeType: AttributeType | VertexUnavailable,
+    valueType: string,
 }
 
 export interface DataConstraintKind {
@@ -484,6 +494,17 @@ class LogicalGraphBuilder {
 
                     type: this.translate_vertex(structure, constraint.type, answerIndex, data) as (Type | VertexUnavailable),
                     label: constraint.label,
+                }
+            }
+            case "value": {
+                return {
+                    tag: "value",
+                    textSpan: constraint.textSpan,
+                    queryCoordinates: coordinates,
+                    queryConstraint: constraint,
+
+                    attributeType: this.translate_vertex(structure, constraint.attributeType, answerIndex, data) as (AttributeType| VertexUnavailable),
+                    valueType: constraint.valueType,
                 }
             }
             case "kind" : {

--- a/src/framework/graph-visualiser/index.ts
+++ b/src/framework/graph-visualiser/index.ts
@@ -137,6 +137,7 @@ export class GraphVisualiser {
                 case "iid": return false;
                 case "kind": return false;
                 case "label": return false;
+                case "value": return false;
             }
         }
         let spans: number[][] = [];

--- a/src/framework/graph-visualiser/visualisation.ts
+++ b/src/framework/graph-visualiser/visualisation.ts
@@ -113,5 +113,6 @@ function putConstraint(converter: ILogicalGraphConverter, answer_index: number, 
     case "iid": break;
     case "label": break;
     case "kind": break;
+    case "value": break;
   }
 }

--- a/src/framework/typedb-driver/query-structure.ts
+++ b/src/framework/typedb-driver/query-structure.ts
@@ -41,7 +41,7 @@ export type QueryVariableInfo = { name: string | null };
 export type QueryConstraintAny = QueryConstraintIsa | QueryConstraintIsaExact | QueryConstraintHas | QueryConstraintLinks |
     QueryConstraintSub | QueryConstraintSubExact | QueryConstraintOwns | QueryConstraintRelates | QueryConstraintPlays |
     QueryConstraintExpression | QueryConstraintFunction | QueryConstraintComparison |
-    QueryConstraintIs | QueryConstraintIid | QueryConstraintKind | QueryConstraintLabel;
+    QueryConstraintIs | QueryConstraintIid | QueryConstraintKind | QueryConstraintValue | QueryConstraintLabel;
 
 export type QueryConstraintSpan = { begin: number, end: number };
 
@@ -171,6 +171,14 @@ export interface QueryConstraintLabel {
 
     type: QueryVertexVariable,
     label: string,
+}
+
+export interface QueryConstraintValue {
+    tag: "value",
+    textSpan: QueryConstraintSpan,
+
+    attributeType: QueryVertexVariable,
+    valueType: string,
 }
 
 export interface QueryConstraintKind {


### PR DESCRIPTION
## Release notes: product changes
Add value type constraint to structure ( `match $x value string;` )
Needs typedb/typedb#7470