### PR TITLE
Fix a bug where schema vertices with no edges were not rendered in graph output

### DIFF
--- a/src/framework/graph-visualiser/converter.ts
+++ b/src/framework/graph-visualiser/converter.ts
@@ -16,7 +16,8 @@ import {
     DataConstraintRelates,
     DataConstraintPlays,
     VertexFunction,
-    VertexExpression, DataConstraintSubExact, DataConstraintIsaExact, DataVertex
+    VertexExpression, DataConstraintSubExact, DataConstraintIsaExact, DataVertex,
+    DataConstraintKind
 } from "./graph";
 import {ILogicalGraphConverter} from "./visualisation";
 import {StudioConverterStructureParameters, StudioConverterStyleParameters} from "./config";
@@ -245,6 +246,10 @@ export class StudioConverter implements ILogicalGraphConverter {
                 let label = `arg[${varNameOrId}]`;
                 this.maybeCreateEdge(answerIndex, constraint, label, arg, functionVertex, queryVertex, functionVertex);
             });
+    }
+
+    put_kind(answer_index: number, constraint: DataConstraintKind): void {
+        this.put_vertex(answer_index, constraint.type, constraint.queryConstraint.type);
     }
 }
 

--- a/src/framework/graph-visualiser/visualisation.ts
+++ b/src/framework/graph-visualiser/visualisation.ts
@@ -2,7 +2,8 @@ import { QueryVertex } from "typedb-driver-http";
 import {
   DataGraph, DataVertex, DataConstraintAny, DataConstraintLinks, DataConstraintHas, DataConstraintIsa,
   DataConstraintOwns, DataConstraintRelates, DataConstraintPlays, DataConstraintSub, DataConstraintFunction,
-  DataConstraintExpression, DataConstraintIsaExact, DataConstraintSubExact
+  DataConstraintExpression, DataConstraintIsaExact, DataConstraintSubExact,
+  DataConstraintKind
 } from "./graph";
 
 /////////////////////////////////
@@ -43,6 +44,8 @@ export interface ILogicalGraphConverter {
   put_expression(answer_index: number, constraint: DataConstraintExpression): void;
 
   put_function(answer_index: number, constraint: DataConstraintFunction): void;
+
+  put_kind(answer_index: number, constraint: DataConstraintKind): void;
 }
 
 export function convertLogicalGraphWith(dataGraph: DataGraph, converter: ILogicalGraphConverter) {
@@ -99,11 +102,14 @@ function putConstraint(converter: ILogicalGraphConverter, answer_index: number, 
       converter.put_function(answer_index, constraint);
       break;
     }
+    case "kind": {
+      converter.put_kind(answer_index, constraint);
+      break;
+    }
     case "comparison": break;
     case "is": break;
     case "iid": break;
     case "label": break;
-    case "kind": break;
     case "value": break;
   }
 }


### PR DESCRIPTION
## Release notes: product changes

We fixed a bug where schema vertex "islands" (with no edges) were not rendered in graph output.

## Motivation

It was confusing.

## Implementation

We add `put_kind` to the graph visualiser framework's `ILogicalGraphConverter` allowing it to handle query constraints tagged `kind`. When Studio's graph output in the Query pane sees a `kind` query constraint, we add a matching schema vertex to the graph for the schema type that it describes (if not already present).

## Additional Information

<img width="1393" height="852" alt="image" src="https://github.com/user-attachments/assets/d6e9b564-768f-4aa0-99b0-77100723da6f" />