### PR TITLE
Sign & notarize studio binaries & dmg for mac

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,8 @@ commands:
         type: string
     steps:
       - run: |
+          # Rename from TypeDB convention to tauri convention
+          export APPLE_PASSWORD=$APPLE_ID_PASSWORD
           if [ -z "${APPLE_ID}" ] || [ -z "${APPLE_PASSWORD}" ] || [ -z "${APPLE_TEAM_ID}" ]; then
             echo "Error: APPLE_ID, APPLE_TEAM_ID, APPLE_PASSWORD must be set to notarize"
             exit 1
@@ -136,6 +138,8 @@ commands:
         type: string
     steps:
       - run: |
+          # Rename from TypeDB convention to tauri convention
+          export APPLE_PASSWORD=$APPLE_ID_PASSWORD
           if [ -z "${APPLE_ID}" ] || [ -z "${APPLE_PASSWORD}" ] || [ -z "${APPLE_TEAM_ID}" ]; then
             echo "Error: APPLE_ID, APPLE_TEAM_ID, APPLE_PASSWORD must be set to notarize"
             exit 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,8 +99,15 @@ commands:
         type: string
     steps:
       - run: |
+          if [ -z "${APPLE_ID}" ] || [ -z "${APPLE_PASSWORD}" ] || [ -z "${APPLE_TEAM_ID}" ]; then
+            echo "Error: APPLE_ID, APPLE_TEAM_ID, APPLE_PASSWORD must be set to notarize"
+            exit 1
+          fi
+          export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+          bazel run @typedb_dependencies//distribution/artifact:create-netrc
           # Newer Homebrew formulae (ca-certificates/openssl@3/python@3.11) can fail their
           # post-install step on the CI image and make `brew install` exit non-zero, aborting the
           # job. The pour itself succeeds, so tolerate the post-install failure and use the
@@ -115,9 +122,10 @@ commands:
           corepack prepare pnpm@10.12.1 --activate
           pnpm build
           rustup target add <<parameters.target-triple>>
-          npx tauri build --target <<parameters.target-triple>>
           # --define version doesn't seem to work, so we just write it into the VERSION file.
           git rev-parse HEAD > VERSION
+          bazel run --define version=$(git rev-parse HEAD) //:setup-mac-signing-keychain
+          npx tauri build --target <<parameters.target-triple>>
           bazel run --define version=$(git rev-parse HEAD) //:deploy-mac-<<parameters.target-arch>>-dmg -- snapshot
 
   deploy-mac-release:
@@ -128,8 +136,15 @@ commands:
         type: string
     steps:
       - run: |
+          if [ -z "${APPLE_ID}" ] || [ -z "${APPLE_PASSWORD}" ] || [ -z "${APPLE_TEAM_ID}" ]; then
+            echo "Error: APPLE_ID, APPLE_TEAM_ID, APPLE_PASSWORD must be set to notarize"
+            exit 1
+          fi
+          export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+          export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+          bazel run@typedb_dependencies//distribution/artifact:create-netrc
           # Newer Homebrew formulae (ca-certificates/openssl@3/python@3.11) can fail their
           # post-install step on the CI image and make `brew install` exit non-zero, aborting the
           # job. The pour itself succeeds, so tolerate the post-install failure and use the
@@ -144,6 +159,7 @@ commands:
           corepack prepare pnpm@10.12.1 --activate
           pnpm build
           rustup target add <<parameters.target-triple>>
+          bazel run //:setup-mac-signing-keychain
           npx tauri build --target <<parameters.target-triple>>
           bazel run //:deploy-mac-<<parameters.target-arch>>-dmg -- release
 

--- a/BUILD
+++ b/BUILD
@@ -4,7 +4,7 @@
 
 load("@typedb_dependencies//distribution:deployment.bzl", "deployment")
 load("@typedb_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@typedb_bazel_distribution//common:rules.bzl", "assemble_targz", "unzip_file", "checksum")
+load("@typedb_bazel_distribution//common:rules.bzl", "assemble_targz", "keychain_setup", "unzip_file", "checksum")
 load("@typedb_bazel_distribution//brew:rules.bzl", "deploy_brew")
 load("@typedb_bazel_distribution//apt:rules.bzl", "deploy_apt")
 load("@typedb_bazel_distribution//artifact:rules.bzl", "artifact_extractor", "deploy_artifact")

--- a/BUILD
+++ b/BUILD
@@ -178,6 +178,28 @@ deploy_apt(
     release = deployment['apt']['release']['upload'],
 )
 
+
+# Mac signing toolchain
+# Signed mac installer
+alias(
+    name = "developer-id-certs",
+    actual = "@vaticle_developer_id_combined//file",
+)
+
+keychain_setup(
+    name = "setup-mac-signing-keychain",
+    keychain_name = "typedb-apple-signing-keychain",
+
+    signing_identities = ":developer-id-certs",
+    signing_identities_password_env = "APPLE_SIGNING_IDENTITIES_PASSWORD",
+
+    partition_list = "apple-tool:,apple:,codesign:",
+    trusted_apps = ["/usr/bin/codesign", "/usr/bin/productsign"],
+
+    # This is the app-specific one that looks like: xxxx-xxxx-xxxx-xxxx .
+    passwords = ["bot@vaticle.com:APPLE_NOTARIZATION_PASSWORD"],
+)
+
 checkstyle_test(
     name = "checkstyle",
     include = glob([

--- a/BUILD
+++ b/BUILD
@@ -184,6 +184,7 @@ deploy_apt(
 alias(
     name = "developer-id-certs",
     actual = "@vaticle_developer_id_combined//file",
+    tags = ["manual"],
 )
 
 keychain_setup(
@@ -197,6 +198,7 @@ keychain_setup(
     trusted_apps = ["/usr/bin/codesign", "/usr/bin/productsign"],
 
     passwords = [],
+    tags = ["manual"],
 )
 
 checkstyle_test(

--- a/BUILD
+++ b/BUILD
@@ -188,7 +188,7 @@ alias(
 
 keychain_setup(
     name = "setup-mac-signing-keychain",
-    keychain_name = "typedb-apple-signing-keychain",
+    keychain_name = "typedb-studio-apple-signing-keychain",
 
     signing_identities = ":developer-id-certs",
     signing_identities_password_env = "APPLE_SIGNING_IDENTITIES_PASSWORD",
@@ -196,8 +196,7 @@ keychain_setup(
     partition_list = "apple-tool:,apple:,codesign:",
     trusted_apps = ["/usr/bin/codesign", "/usr/bin/productsign"],
 
-    # This is the app-specific one that looks like: xxxx-xxxx-xxxx-xxxx .
-    passwords = ["bot@vaticle.com:APPLE_NOTARIZATION_PASSWORD"],
+    passwords = [],
 )
 
 checkstyle_test(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -28,6 +28,14 @@ git_override(
 bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")
 git_override(
     module_name = "typedb_bazel_distribution",
-    remote = "https://github.com/typedb/bazel-distribution",
-    commit = "dd811cf28715bbce8374e5e0f9defaf772e7dd36",
+    remote = "https://github.com/krishnangovindraj/bazel-distribution",
+    commit = "d31c266ed44018c3c0c36fed3c1d5f7fbc6cdbae",
+)
+
+http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+http_file(
+    name = "vaticle_developer_id_combined",
+    url = "https://repo.typedb.com/basic/private-tools/raw/files/VaticleDeveloperIDCombined.p12",
+    sha256 = "e6da59e0698ea876c89ac2a19c87ac6e6936df98ee5df31d8895a09ef26b15c7",
+    downloaded_file_path = "VaticleDeveloperIDCombined.p12",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -28,8 +28,8 @@ git_override(
 bazel_dep(name = "typedb_bazel_distribution", version = "0.0.0")
 git_override(
     module_name = "typedb_bazel_distribution",
-    remote = "https://github.com/krishnangovindraj/bazel-distribution",
-    commit = "d31c266ed44018c3c0c36fed3c1d5f7fbc6cdbae",
+    remote = "https://github.com/typedb/bazel-distribution",
+    commit = "8756119e8ad5cd52d8a25f0d0204d6ff29dccebf",
 )
 
 http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -39,7 +39,7 @@
       }
     },
     "macOS": {
-      "signingIdentity": "-"
+      "signingIdentity": "Developer ID Application: Vaticle LTD (RHKH8FP9SX)"
     }
   }
 }


### PR DESCRIPTION
## Release notes: product changes
Based on Tauri's local code signing & Developer ID based notarization workflows ([here](https://v2.tauri.app/distribute/sign/macos/))

## Motivation
No scary messages

## Implementation
Our tool from `bazel-distribution` sets up the keychain, and passes the certificate subject to Tauri, which signs
For notarisation, we just need to set the right environment variables.

Test commit which deployed artifacts: https://github.com/typedb/typedb-studio/tree/9d6cc3e0a3bb10051070cdc45427433d358ecbbb